### PR TITLE
change queryStream to only look at the last result.

### DIFF
--- a/lib/mongodb_partition.js
+++ b/lib/mongodb_partition.js
@@ -131,13 +131,13 @@ MdbPartition.prototype.queryAll = function (callback) {
 
 MdbPartition.prototype.queryStream = function (streamId, fromEventSequence, callback) {
   var self = this;
-  // if from event sequence is 0 / undefined - use fallback..
-  if (_.isNil(fromEventSequence) || fromEventSequence === 0) {
-    return self.queryStreamFallback(streamId, fromEventSequence, callback);
-  }
   if (typeof fromEventSequence === 'function') {
     callback = fromEventSequence;
     fromEventSequence = 0;
+  }
+  // if from event sequence is 0 / undefined - use fallback..
+  if (_.isNil(fromEventSequence) || fromEventSequence === 0) {
+    return self.queryStreamFallback(streamId, fromEventSequence, callback);
   }
   return new Promise(function (resolve, reject) {
     // use limit 1 and only include events from requested version - if we are unable to find the correct event, use fallback...

--- a/lib/mongodb_partition.js
+++ b/lib/mongodb_partition.js
@@ -1,6 +1,7 @@
 var Promise = require('bluebird');
 var ConcurrencyError = require('tapeworm').ConcurrencyError;
 var DuplicateCommitError = require('tapeworm').DuplicateCommitError;
+var _ = require('lodash');
 
 var CONCURRENCY_EXCEPTION_CODE = 11000;
 
@@ -83,9 +84,7 @@ MdbPartition.prototype.append = function (commit, callback) {
   var self = this;
   commit.isDispatched = false;
   commit.createDateTime = new Date();
-
   return new Promise(function (resolve, reject) {
-
     self._commits.insert(commit, function (err, result) {
       if (err) {
         if (err.code === CONCURRENCY_EXCEPTION_CODE) {
@@ -102,7 +101,7 @@ MdbPartition.prototype.append = function (commit, callback) {
         resolve(commit);
       }
     });
-  });
+  }).nodeify(callback);
 }
 
 MdbPartition.prototype.markAsDispatched = function (commit, callback) {
@@ -131,6 +130,52 @@ MdbPartition.prototype.queryAll = function (callback) {
 };
 
 MdbPartition.prototype.queryStream = function (streamId, fromEventSequence, callback) {
+  var self = this;
+  // if from event sequence is 0 / undefined - use fallback..
+  if (_.isNil(fromEventSequence) || fromEventSequence === 0) {
+    return self.queryStreamFallback(streamId, fromEventSequence, callback);
+  }
+  if (typeof fromEventSequence === 'function') {
+    callback = fromEventSequence;
+    fromEventSequence = 0;
+  }
+  return new Promise(function (resolve, reject) {
+    // use limit 1 and only include events from requested version - if we are unable to find the correct event, use fallback...
+    self._commits.find({ streamId: streamId, 'events.version': { $gte: fromEventSequence } }).limit(1).sort({ commitSequence: -1 }).toArray(function (err, commits) {
+      if (err) {
+        reject(err);
+      } else {
+        // assume this will happen most of the times
+        if (commits.length === 0) {
+          resolve([]);
+          return;
+        }
+
+        var events = _.get(commits, '[0].events', []);
+        // check if our requested event version is out of reach for the last commit - need to use fallback then..
+        if (events[0].version > fromEventSequence) {
+          // problem... use fallback.
+          return self.queryStreamFallback(streamId, fromEventSequence).then(function (res) {
+            resolve(res);
+          })
+        }
+
+        // find every event that has version equal or larger than fromEventSequence
+        var foundEvents = [];
+        for (var i = 0; i < events.length; i++) {
+          if (events[i].version >= fromEventSequence) {
+            foundEvents.push(events[i]);
+          }
+        }
+        var commit = commits[0];
+        commit.events = foundEvents;
+        resolve([commit]);
+      }
+    });
+  }).nodeify(callback);
+}
+
+MdbPartition.prototype.queryStreamFallback = function (streamId, fromEventSequence, callback) {
   if (typeof fromEventSequence === 'function') {
     callback = fromEventSequence;
     fromEventSequence = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapeworm_persistence_store_mongodb",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "index.js",
   "directories": {

--- a/test/persistence.js
+++ b/test/persistence.js
@@ -84,21 +84,90 @@ describe('indexeddb_persistence', function () {
       });
     });
 
-    it('two commits in one stream are visible', function () {
+    it('two commits in one stream are visible', function (done) {
       var store = new Store(getDb());
       store.openPartition('1').then(function (partition) {
         var events = [new Event(uuid(), 'type1', { test: 11 })];
         var commit = new Commit(uuid(), 'master', '1', 0, events);
-        partition.append(commit);
-        var events = [new Event(uuid(), 'type2', { test: 22 })];
-        var commit = new Commit(uuid(), 'master', '1', 1, events);
-        partition.append(commit);
-        partition.queryAll().then(function (res) {
-          res.length.should.equal(2);
+        partition.append(commit, function () {
+          var events = [new Event(uuid(), 'type2', { test: 22 })];
+          var commit = new Commit(uuid(), 'master', '1', 1, events);
+          partition.append(commit, function () {
+            partition.queryAll().then(function (res) {
+              res.length.should.equal(2);
+              done();
+            });
+          });
         });
       });
     });
   });
+
+  it('query stream from version without fallback', function (done) {
+    var store = new Store(getDb());
+    store.openPartition('1').then(function (partition) {
+      var streamId = uuid();
+      var events = [
+        new Event(uuid(), 'event-1', { test: 11, version: 0 }),
+        new Event(uuid(), 'event-2', { test: 12, version: 1 }),
+        new Event(uuid(), 'event-3', { test: 13, version: 2 })
+      ];
+      events.forEach(function (e) { e.version = e.data.version }); // fake version...
+      var commit = new Commit(uuid(), 'master', streamId, 0, events);
+      partition.append(commit).then(function () {
+        var events = [
+          new Event(uuid(), 'event-4', { test: 14, version: 3 }),
+          new Event(uuid(), 'event-5', { test: 15, version: 4 }),
+          new Event(uuid(), 'event-6', { test: 16, version: 5 })
+        ];
+        events.forEach(function (e) { e.version = e.data.version }); // fake version...
+        var commit = new Commit(uuid(), 'master', streamId, 1, events);
+        partition.append(commit).then(function () {
+          partition.queryStream(streamId, 4).then((res) => {
+            res[0].events[0].version.should.equal(4);
+            res[0].events[1].version.should.equal(5);
+            res[0].commitSequence.should.equal(1)
+            done();
+          })
+        });
+      });
+    });
+  });
+
+  it('query stream from version with fallback', function (done) {
+    var store = new Store(getDb());
+    store.openPartition('1').then(function (partition) {
+      var streamId = uuid();
+      var events = [
+        new Event(uuid(), 'event-1', { test: 11, version: 0 }),
+        new Event(uuid(), 'event-2', { test: 12, version: 1 }),
+        new Event(uuid(), 'event-3', { test: 13, version: 2 })
+      ];
+      events.forEach(function (e) { e.version = e.data.version }); // fake version...
+      var commit = new Commit(uuid(), 'master', streamId, 0, events);
+      partition.append(commit).then(function () {
+        var events = [
+          new Event(uuid(), 'event-4', { test: 14, version: 3 }),
+          new Event(uuid(), 'event-5', { test: 15, version: 4 }),
+          new Event(uuid(), 'event-6', { test: 16, version: 5 })
+        ];
+        events.forEach(function (e) { e.version = e.data.version }); // fake version...
+        var commit = new Commit(uuid(), 'master', streamId, 1, events);
+        partition.append(commit).then(function () {
+          partition.queryStream(streamId, 2).then((res) => {
+            res.length.should.equal(2)
+            res[0].events[0].version.should.equal(2);
+            res[1].events[2].version.should.equal(5);
+            res[0].commitSequence.should.equal(0)
+            res[1].commitSequence.should.equal(1)
+            done();
+          })
+        });
+      });
+    });
+  });
+
+
   describe('#snapshot', function () {
     it('should return previously stored snapshot', function (done) {
       var store = new Store(getDb());
@@ -142,10 +211,10 @@ describe('indexeddb_persistence', function () {
           .then(function () {
             done(new Error("Should have DuplicateCommitError"));
           }).catch(PersistenceDuplicateCommitError, function (err) {
-            done();
-          }).catch(function (err) {
-            done(err);
-          });
+          done();
+        }).catch(function (err) {
+          done(err);
+        });
       });
     });
   });


### PR DESCRIPTION
Since most queries to the stream happens in conjunction with a `loadSnapshot` call, most calls to this function will at most need the last commit on the stream. Use old version as fallback if requested eventSequence is 0, or if cannot react correct commit with given fromEventSequence