### PR TITLE
changes queryStream to not use events.version in query.

### DIFF
--- a/lib/mongodb_partition.js
+++ b/lib/mongodb_partition.js
@@ -140,12 +140,12 @@ MdbPartition.prototype.queryStream = function (streamId, fromEventSequence, call
     return self.queryStreamFallback(streamId, fromEventSequence, callback);
   }
   return new Promise(function (resolve, reject) {
-    // use limit 1 and only include events from requested version - if we are unable to find the correct event, use fallback...
-    self._commits.find({ streamId: streamId, 'events.version': { $gte: fromEventSequence } }).limit(1).sort({ commitSequence: -1 }).toArray(function (err, commits) {
+    // use limit 1 to get last commit - if we are unable to find the correct event, use fallback...
+    self._commits.find({ streamId: streamId }).limit(1).sort({ commitSequence: -1 }).toArray(function (err, commits) {
       if (err) {
         reject(err);
       } else {
-        // assume this will happen most of the times
+        // assume this will probably not happen
         if (commits.length === 0) {
           resolve([]);
           return;
@@ -167,6 +167,13 @@ MdbPartition.prototype.queryStream = function (streamId, fromEventSequence, call
             foundEvents.push(events[i]);
           }
         }
+
+        // assume this will happen most of the time.
+        if (foundEvents.length === 0) {
+          resolve([]);
+          return;
+        }
+
         var commit = commits[0];
         commit.events = foundEvents;
         resolve([commit]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tapeworm_persistence_store_mongodb",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
rely on limit och check in memory instead